### PR TITLE
feat: v2 of node-dev images with Yarn support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,12 @@ jobs:
           name: Lint node-dev/12.10.0-v1 dockerfile
           command: hadolint ./images/node-dev/12-10-0-v1/Dockerfile
       - run:
+          name: Lint node-dev/10.16.3-v2 dockerfile
+          command: hadolint ./images/node-dev/10-16-3-v2/Dockerfile
+      - run:
+          name: Lint node-dev/12.10.0-v2 dockerfile
+          command: hadolint ./images/node-dev/12-10-0-v2/Dockerfile
+      - run:
           name: Lint node-prod/10.16.3-v1 dockerfile
           command: hadolint ./images/node-prod/10-16-3-v1/Dockerfile
       - run:
@@ -31,6 +37,12 @@ jobs:
       - run:
           name: Docker build node-dev/12.10.0-v1
           command: ./images/node-dev/12-10-0-v1/build.sh
+      - run:
+          name: Docker build node-dev/10.16.3-v2
+          command: ./images/node-dev/10-16-3-v2/build.sh
+      - run:
+          name: Docker build node-dev/12.10.0-v2
+          command: ./images/node-dev/12-10-0-v2/build.sh
       - run:
           name: Docker build node-prod/10.16.3-v1
           command: ./images/node-prod/10-16-3-v1/build.sh
@@ -52,6 +64,8 @@ jobs:
               docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
               ./images/node-dev/10-16-3-v1/push.sh
               ./images/node-dev/12-10-0-v1/push.sh
+              ./images/node-dev/10-16-3-v2/push.sh
+              ./images/node-dev/12-10-0-v2/push.sh
               ./images/node-prod/10-16-3-v1/push.sh
               ./images/node-prod/12-10-0-v1/push.sh
             else

--- a/images/node-dev/10-16-3-v2/Dockerfile
+++ b/images/node-dev/10-16-3-v2/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:10.16.3-alpine
+
+# hadolint ignore=DL3018
+RUN apk --no-cache --update add bash curl less shadow su-exec tini vim python2 make
+SHELL ["/bin/bash", "-o", "pipefail", "-o", "errexit", "-u", "-c"]
+
+# Allow yarn/npm to create ./node_modules
+RUN chown node:node .
+
+# Install the latest version of NPM (as of when this
+# base image is built)
+RUN npm i -g npm@latest
+
+COPY ./scripts /usr/local/src/app-scripts
+
+WORKDIR /usr/local/src/app
+ENV PATH=$PATH:/usr/local/src/app/node_modules/.bin \
+    BUILD_ENV=development NODE_ENV=development
+
+# hadolint ignore=DL3002
+USER root
+ENTRYPOINT ["tini", "--", "/usr/local/src/app-scripts/entrypoint.sh"]

--- a/images/node-dev/10-16-3-v2/build.sh
+++ b/images/node-dev/10-16-3-v2/build.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Please Use Google Shell Style: https://google.github.io/styleguide/shell.xml
+
+# ---- Start unofficial bash strict mode boilerplate
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -o errexit  # always exit on error
+set -o errtrace # trap errors in functions as well
+set -o pipefail # don't ignore exit codes when piping output
+set -o posix    # more strict failures in subshells
+# set -x          # enable debugging
+
+IFS=$'\n\t'
+# ---- End unofficial bash strict mode boilerplate
+
+this_dir="$(dirname "${BASH_SOURCE[0]}")"
+
+docker build -t reactioncommerce/node-dev:10.16.3-v2 "${this_dir}"

--- a/images/node-dev/10-16-3-v2/push.sh
+++ b/images/node-dev/10-16-3-v2/push.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Please Use Google Shell Style: https://google.github.io/styleguide/shell.xml
+
+# ---- Start unofficial bash strict mode boilerplate
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -o errexit  # always exit on error
+set -o errtrace # trap errors in functions as well
+set -o pipefail # don't ignore exit codes when piping output
+set -o posix    # more strict failures in subshells
+# set -x          # enable debugging
+
+IFS=$'\n\t'
+# ---- End unofficial bash strict mode boilerplate
+
+this_dir="$(dirname "${BASH_SOURCE[0]}")"
+
+docker push reactioncommerce/node-dev:10.16.3-v2

--- a/images/node-dev/10-16-3-v2/scripts/entrypoint.sh
+++ b/images/node-dev/10-16-3-v2/scripts/entrypoint.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Please Use Google Shell Style: https://google.github.io/styleguide/shell.xml
+
+# ---- Start unofficial bash strict mode boilerplate
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -o errexit  # always exit on error
+set -o errtrace # trap errors in functions as well
+set -o pipefail # don't ignore exit codes when piping output
+set -o posix    # more strict failures in subshells
+# set -x          # enable debugging
+
+IFS=$'\n\t'
+# ---- End unofficial bash strict mode boilerplate
+
+run_user="node"
+# change the node user's uid:gid to match the repo root directory's
+usermod --uid "$(stat -c "%u" .)" --non-unique "${run_user}" |& grep -v "no changes" || true
+"$(dirname "${BASH_SOURCE[0]}")/fix-volumes.sh"
+command=(npm run start:dev)
+if [[ $# -gt 0 ]]; then
+  # shellcheck disable=SC2206
+  command=($@)
+fi
+echo "Installing dependencies..."
+if [[ -f /usr/local/src/app/yarn.lock ]]; then
+  echo "(Using Yarn because there is a yarn.lock file)"
+  su-exec node yarn install
+else
+  su-exec node npm install --no-audit
+fi
+echo "Starting the project in development mode..."
+unset IFS
+exec su-exec "${run_user}" "${command[@]}"

--- a/images/node-dev/10-16-3-v2/scripts/fix-volumes.sh
+++ b/images/node-dev/10-16-3-v2/scripts/fix-volumes.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Please Use Google Shell Style: https://google.github.io/styleguide/shell.xml
+
+# ---- Start unofficial bash strict mode boilerplate
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -o errexit  # always exit on error
+set -o errtrace # trap errors in functions as well
+set -o pipefail # don't ignore exit codes when piping output
+set -o posix    # more strict failures in subshells
+# set -x          # enable debugging
+
+IFS=$'\n\t'
+# ---- End unofficial bash strict mode boilerplate
+
+volumes=$(mount | grep -E '^/dev/' | grep -Ev ' on /etc/' || true)
+if [[ -z "${volumes}" ]]; then
+  exit
+fi
+owner=$(stat -c "%u:%g" .)
+echo "${volumes}" | awk '{print $3}' | {
+  while IFS= read -r dir; do
+    echo "${dir}"
+    mkdir -p "${dir}"
+    old_owner=$(stat -c "%u:%g" "${dir}")
+    if [[ "$1" != "--force" && "${old_owner}" == "${owner}" ]]; then
+      continue
+    fi
+    printf "Fixing volume %s (before=%s after=%s)…" "${dir}" "${old_owner}" "${owner}"
+    chown -R "${owner}" "${dir}"
+    chmod -R a+r,u+rw "${dir}"
+    echo "✓"
+  done
+}

--- a/images/node-dev/12-10-0-v2/Dockerfile
+++ b/images/node-dev/12-10-0-v2/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:12.10.0-alpine
+
+# hadolint ignore=DL3018
+RUN apk --no-cache --update add bash curl less shadow su-exec tini vim python2 make
+SHELL ["/bin/bash", "-o", "pipefail", "-o", "errexit", "-u", "-c"]
+
+# Allow yarn/npm to create ./node_modules
+RUN chown node:node .
+
+# Install the latest version of NPM (as of when this
+# base image is built)
+RUN npm i -g npm@latest
+
+COPY ./scripts /usr/local/src/app-scripts
+
+WORKDIR /usr/local/src/app
+ENV PATH=$PATH:/usr/local/src/app/node_modules/.bin \
+    BUILD_ENV=development NODE_ENV=development
+
+# hadolint ignore=DL3002
+USER root
+ENTRYPOINT ["tini", "--", "/usr/local/src/app-scripts/entrypoint.sh"]

--- a/images/node-dev/12-10-0-v2/build.sh
+++ b/images/node-dev/12-10-0-v2/build.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Please Use Google Shell Style: https://google.github.io/styleguide/shell.xml
+
+# ---- Start unofficial bash strict mode boilerplate
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -o errexit  # always exit on error
+set -o errtrace # trap errors in functions as well
+set -o pipefail # don't ignore exit codes when piping output
+set -o posix    # more strict failures in subshells
+# set -x          # enable debugging
+
+IFS=$'\n\t'
+# ---- End unofficial bash strict mode boilerplate
+
+this_dir="$(dirname "${BASH_SOURCE[0]}")"
+
+docker build -t reactioncommerce/node-dev:12.10.0-v2 "${this_dir}"

--- a/images/node-dev/12-10-0-v2/push.sh
+++ b/images/node-dev/12-10-0-v2/push.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Please Use Google Shell Style: https://google.github.io/styleguide/shell.xml
+
+# ---- Start unofficial bash strict mode boilerplate
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -o errexit  # always exit on error
+set -o errtrace # trap errors in functions as well
+set -o pipefail # don't ignore exit codes when piping output
+set -o posix    # more strict failures in subshells
+# set -x          # enable debugging
+
+IFS=$'\n\t'
+# ---- End unofficial bash strict mode boilerplate
+
+this_dir="$(dirname "${BASH_SOURCE[0]}")"
+
+docker push reactioncommerce/node-dev:12.10.0-v2

--- a/images/node-dev/12-10-0-v2/scripts/entrypoint.sh
+++ b/images/node-dev/12-10-0-v2/scripts/entrypoint.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Please Use Google Shell Style: https://google.github.io/styleguide/shell.xml
+
+# ---- Start unofficial bash strict mode boilerplate
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -o errexit  # always exit on error
+set -o errtrace # trap errors in functions as well
+set -o pipefail # don't ignore exit codes when piping output
+set -o posix    # more strict failures in subshells
+# set -x          # enable debugging
+
+IFS=$'\n\t'
+# ---- End unofficial bash strict mode boilerplate
+
+run_user="node"
+# change the node user's uid:gid to match the repo root directory's
+usermod --uid "$(stat -c "%u" .)" --non-unique "${run_user}" |& grep -v "no changes" || true
+"$(dirname "${BASH_SOURCE[0]}")/fix-volumes.sh"
+command=(npm run start:dev)
+if [[ $# -gt 0 ]]; then
+  # shellcheck disable=SC2206
+  command=($@)
+fi
+echo "Installing dependencies..."
+if [[ -f /usr/local/src/app/yarn.lock ]]; then
+  echo "(Using Yarn because there is a yarn.lock file)"
+  su-exec node yarn install
+else
+  su-exec node npm install --no-audit
+fi
+echo "Starting the project in development mode..."
+unset IFS
+exec su-exec "${run_user}" "${command[@]}"

--- a/images/node-dev/12-10-0-v2/scripts/fix-volumes.sh
+++ b/images/node-dev/12-10-0-v2/scripts/fix-volumes.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Please Use Google Shell Style: https://google.github.io/styleguide/shell.xml
+
+# ---- Start unofficial bash strict mode boilerplate
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -o errexit  # always exit on error
+set -o errtrace # trap errors in functions as well
+set -o pipefail # don't ignore exit codes when piping output
+set -o posix    # more strict failures in subshells
+# set -x          # enable debugging
+
+IFS=$'\n\t'
+# ---- End unofficial bash strict mode boilerplate
+
+volumes=$(mount | grep -E '^/dev/' | grep -Ev ' on /etc/' || true)
+if [[ -z "${volumes}" ]]; then
+  exit
+fi
+owner=$(stat -c "%u:%g" .)
+echo "${volumes}" | awk '{print $3}' | {
+  while IFS= read -r dir; do
+    echo "${dir}"
+    mkdir -p "${dir}"
+    old_owner=$(stat -c "%u:%g" "${dir}")
+    if [[ "$1" != "--force" && "${old_owner}" == "${owner}" ]]; then
+      continue
+    fi
+    printf "Fixing volume %s (before=%s after=%s)…" "${dir}" "${old_owner}" "${owner}"
+    chown -R "${owner}" "${dir}"
+    chmod -R a+r,u+rw "${dir}"
+    echo "✓"
+  done
+}

--- a/images/node-dev/CHANGELOG.md
+++ b/images/node-dev/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Change Log
+
+## v2
+
+The `node-dev` images `10.16.3-v2` and `12.10.0-v2` are the same as `v1` except that the entry point script, if it sees a `yarn.lock` file, will install dependencies using Yarn instead.


### PR DESCRIPTION
Add node-dev `v2` images which, if they see `yarn.lock`, will install dependencies on startup using Yarn instead of NPM.

Reviewer note: All files are identical to their `v1` versions except this bit changed in the entrypoint script:

```bash
if [[ -f /usr/local/src/app/yarn.lock ]]; then
  echo "(Using Yarn because there is a yarn.lock file)"
  su-exec node yarn install
else
  su-exec node npm install --no-audit
fi
```