### PR TITLE
fix: Add python2 dep for libvips native add-on build

### DIFF
--- a/images/node-prod/10.16.3-v1/Dockerfile
+++ b/images/node-prod/10.16.3-v1/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:10.16.3-alpine
 
 # hadolint ignore=DL3018
-RUN apk --no-cache add bash curl less tini vim make
+RUN apk --no-cache add bash curl less tini vim make python2
 SHELL ["/bin/bash", "-o", "pipefail", "-o", "errexit", "-u", "-c"]
 
 WORKDIR /usr/local/src/app

--- a/images/node-prod/12.10.0-v1/Dockerfile
+++ b/images/node-prod/12.10.0-v1/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:12.10.0-alpine
 
 # hadolint ignore=DL3018
-RUN apk --no-cache add bash curl less tini vim make
+RUN apk --no-cache add bash curl less tini vim make python2
 SHELL ["/bin/bash", "-o", "pipefail", "-o", "errexit", "-u", "-c"]
 
 WORKDIR /usr/local/src/app


### PR DESCRIPTION
resolves #6

@aldeed I should check with you on whether this is OK to fix by editing files or do I need to copy to `-v2`?