### PR TITLE
feat: add meteor/1.8.1-v1 image

### DIFF
--- a/images/meteor/1.8.1-v1/Dockerfile
+++ b/images/meteor/1.8.1-v1/Dockerfile
@@ -1,0 +1,21 @@
+# Some Meteor commands fail if we use one of the slimmer Node images.
+# Meteor 1.8.1 ships with Node 8.15.1. Be sure to keep these two versions in sync
+# when making new versions of this image.
+FROM node:8.15.1
+
+SHELL ["/bin/bash", "-o", "pipefail", "-o", "errexit", "-u", "-c"]
+
+ENV METEOR_VERSION 1.8.1
+ENV PATH $PATH:/home/node/.meteor
+
+USER node
+
+# Install Meteor. Copy the install script to a temp file first, so that we can
+# replace the hard-coded `RELEASE` var in the script with the release we want installed.
+RUN wget -O /tmp/install_meteor.sh https://install.meteor.com \
+ && sed -i.bak "s/RELEASE=.*/RELEASE=\"$METEOR_VERSION\"/g" /tmp/install_meteor.sh \
+ && printf "\\n[-] Installing Meteor %s...\\n" "$METEOR_VERSION" \
+ && sh /tmp/install_meteor.sh \
+ && rm /tmp/install_meteor.sh
+
+LABEL maintainer="Reaction Commerce <engineering@reactioncommerce.com>"

--- a/images/meteor/README.md
+++ b/images/meteor/README.md
@@ -1,0 +1,26 @@
+# reactioncommerce/meteor
+
+These Docker images are intended to be used as base images for projects that need to run `meteor` CLI commands in the container.
+
+There are multiple versions of the Docker image, which are pushed to DockerHub as different tags, but the only difference is in which Node image they are based on and which version of Meteor they include. They are tagged with the the Meteor version and include the same Node version that version of Meteor ships with.
+
+## Assumptions
+
+None
+
+## Usage
+
+Create a file named `Dockerfile` in the root of your project. Put this in the file, substituting the version of Meteor you need (if an image for it exists in this repo):
+
+```
+FROM reactioncommerce/meteor:1.8.1-v1
+```
+
+After the `FROM` line, add other directives that are necessary to build your image.
+
+To build your image and try running your app:
+
+```bash
+docker build . -t my-app
+docker run my-app
+```


### PR DESCRIPTION
Many Meteor projects have the same initial requirements for a Docker image (either for development or for building the production app in):
- Specific Meteor version
- Specific Node and NPM versions that ship with that Meteor version
- `meteor` command in PATH

By publishing this as a base image on DockerHub, multiple Meteor projects on the same version of Meteor can all share the same base. This means the image needs to be downloaded only once and will take up less space on a development computer. It also shaves off a couple minutes of build time that would be necessary to download and install Meteor when building each Dockerfile that references this image.

For usage, see the new README.