### PR TITLE
chore: docker build and push in same CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,12 +26,15 @@ jobs:
       - run:
           command: ./dockerfiles.sh build
 
-  docker-push:
+  docker-build-push:
     <<: *defaults
     steps:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
+      - run:
+          name: Docker Build
+          command: ./dockerfiles.sh build
       - run:
           name: Docker Push
           command: |
@@ -51,10 +54,13 @@ workflows:
           context: reaction-build-read
           requires:
             - lint-dockerfiles
-      - docker-push:
+          filters:
+            branches:
+              ignore: trunk
+      - docker-build-push:
           context: reaction-publish-docker
           requires:
-            - docker-build
+            - lint-dockerfiles
           filters:
             branches:
               only: trunk


### PR DESCRIPTION
CI config is relying on Docker builds from previous job to be available in next job, but this turns out to be not always true. From CircleCI docs:

> Every layer built in a previous job will be accessible in the Remote Docker Environment. However, in some cases your job may run in a clean environment, even if the configuration specifies docker_layer_caching: true.

Instead, we'll build and push in the same job for `trunk` branch only.