### PR TITLE
New meteor-dev image

### DIFF
--- a/dockerfiles.sh
+++ b/dockerfiles.sh
@@ -48,7 +48,7 @@ main() {
         cp -a "${context_dir}/." "${root_build_dir}"
 
         # Do build
-        docker build -t "reactioncommerce/${name}:${tag}" "${root_build_dir}"
+        docker build --no-cache -t "reactioncommerce/${name}:${tag}" "${root_build_dir}"
         ;;
       push)
         docker push "reactioncommerce/${name}:${tag}"

--- a/images/meteor-dev/1.8.1-v1/Dockerfile
+++ b/images/meteor-dev/1.8.1-v1/Dockerfile
@@ -1,0 +1,20 @@
+FROM reactioncommerce/meteor:1.8.1-v1
+
+# hadolint ignore=DL3002
+USER root
+
+RUN apt-get update && apt-get install sudo
+
+COPY ./scripts /usr/local/src/app-scripts
+
+# Ensure that all files will be linked in owned by node user.
+# Every directory that will be listed in `volumes` section of
+# docker-compose.yml needs to be pre-created and chown'd here.
+# See https://github.com/docker/compose/issues/3270#issuecomment-363478501
+RUN mkdir -p /usr/local/src/app && chown node:node /usr/local/src/app
+
+WORKDIR /usr/local/src/app
+ENV PATH=$PATH:/usr/local/src/app/node_modules/.bin \
+    BUILD_ENV=development NODE_ENV=development
+
+ENTRYPOINT ["/usr/local/src/app-scripts/entrypoint.sh"]

--- a/images/meteor-dev/1.8.1-v1/scripts/entrypoint.sh
+++ b/images/meteor-dev/1.8.1-v1/scripts/entrypoint.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Please Use Google Shell Style: https://google.github.io/styleguide/shell.xml
+
+# ---- Start unofficial bash strict mode boilerplate
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -o errexit  # always exit on error
+set -o errtrace # trap errors in functions as well
+set -o pipefail # don't ignore exit codes when piping output
+set -o posix    # more strict failures in subshells
+# set -x          # enable debugging
+
+IFS=$'\n\t'
+# ---- End unofficial bash strict mode boilerplate
+
+run_user="node"
+# change the node user's uid:gid to match the repo root directory's
+# usermod --uid "$(stat -c "%u" .)" --non-unique "${run_user}"
+"$(dirname "${BASH_SOURCE[0]}")/fix-volumes.sh"
+
+command=(npm run start:dev)
+is_default_command=true
+if [[ $# -gt 0 ]]; then
+  # shellcheck disable=SC2206
+  command=($@)
+  is_default_command=false
+fi
+
+echo "Installing dependencies..."
+if [[ -f /usr/local/src/app/yarn.lock ]]; then
+  echo "(Using Yarn because there is a yarn.lock file)"
+  sudo -u "${run_user}" -H -s yarn install
+else
+  sudo -u "${run_user}" -H -s npm install --no-audit
+fi
+
+if [[ "${is_default_command}" = true ]]; then
+  echo "Starting the project in development mode..."
+fi
+
+unset IFS
+exec sudo -u "${run_user}" -H -s "${command[@]}"

--- a/images/meteor-dev/1.8.1-v1/scripts/fix-volumes.sh
+++ b/images/meteor-dev/1.8.1-v1/scripts/fix-volumes.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Please Use Google Shell Style: https://google.github.io/styleguide/shell.xml
+
+# ---- Start unofficial bash strict mode boilerplate
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -o errexit  # always exit on error
+set -o errtrace # trap errors in functions as well
+set -o pipefail # don't ignore exit codes when piping output
+set -o posix    # more strict failures in subshells
+# set -x          # enable debugging
+
+IFS=$'\n\t'
+# ---- End unofficial bash strict mode boilerplate
+
+volumes=$(mount | grep -E '^/dev/' | grep -Ev ' on /etc/' || true)
+if [[ -z "${volumes}" ]]; then
+  exit
+fi
+owner=$(stat -c "%u:%g" .)
+# if [[ "${owner}" =~ ^0: ]]; then
+#   echo "$(basename "$0") aborting instead of chowning to root."
+#   echo "Found owner ${owner} on ${PWD}."
+#   exit
+# fi
+
+echo "${volumes}" | awk '{print $3}' | {
+  while IFS= read -r dir; do
+    echo "${dir}"
+    mkdir -p "${dir}"
+    chown -R node:node "${dir}"
+    echo "✓"
+  done
+}

--- a/images/meteor-dev/README.md
+++ b/images/meteor-dev/README.md
@@ -1,0 +1,28 @@
+# reactioncommerce/meteor-dev
+
+These Docker images are intended to be used as images for running Reaction Commerce Meteor projects in while developing. There is nothing overly specific to Reaction in them; you could use them for any Meteor project as long as you follow the same patterns.
+
+There are multiple versions of the Docker image, which are pushed to DockerHub as different tags, but the only difference is in which Meteor image they are based on, or in other words, which version of Meteor will run your program.
+
+> `meteor-dev` images are the same as `node-dev` images except with Meteor preinstalled
+
+## Assumptions
+
+- Your project uses NPM and not Yarn.
+- Your project has a root `package.json` with a "start:dev" script that runs the Meteor project in development mode
+
+## Usage
+
+Under the service in `docker-compose.yml`:
+
+```
+image: reactioncommerce/meteor-dev:1.8.1-v1
+volumes:
+  - .:/usr/local/src/app:cached
+  - meteor_local:/usr/local/src/app/.meteor/local
+  - node_modules:/usr/local/src/app/node_modules # do not link node_modules in, and persist it between dc up runs
+```
+
+This means "use the meteor-dev image and link in all files and folders in the project root directory except node_modules and .meteor/local".
+
+The image is configured to always fix volume mount issues and run `npm install` when you start a new container.


### PR DESCRIPTION
WORK IN PROGRESS

Still to do:
- `meteor` commands fail. `meteor` is added to PATH in `meteor` base image, but may need to do it again for root user
- get UID/volume fixing working on linux hosts

Tips for testing:
- Use `./dockerfiles.sh build images/meteor-dev/1.8.1-v1/Dockerfile` to build. This now uses `--no-cache` option
- In Meteor repo, do `docker-compose down --rmi local -v --remove-orphans` followed by `docker-compose up --force-recreate` every time to be sure you're getting latest. 
- To check file ownership, do `docker-compose run --rm reaction-admin sh` (assuming testing in `reaction-admin` repo) and then `ls -al`.