### PR TITLE
fix: Never usermod to uid 0 in entrypoint.sh

### DIFF
--- a/images/node-dev/10.16.3-v3/Dockerfile
+++ b/images/node-dev/10.16.3-v3/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:10.16.3-alpine
+
+# hadolint ignore=DL3018
+RUN apk --no-cache --update add bash curl less shadow su-exec tini vim python2 make
+SHELL ["/bin/bash", "-o", "pipefail", "-o", "errexit", "-u", "-c"]
+
+# Allow yarn/npm to create ./node_modules
+RUN chown node:node .
+
+# Install the latest version of NPM (as of when this
+# base image is built)
+RUN npm i -g npm@latest
+
+COPY ./scripts /usr/local/src/app-scripts
+
+WORKDIR /usr/local/src/app
+ENV PATH=$PATH:/usr/local/src/app/node_modules/.bin \
+    BUILD_ENV=development NODE_ENV=development
+
+# hadolint ignore=DL3002
+USER root
+ENTRYPOINT ["tini", "--", "/usr/local/src/app-scripts/entrypoint.sh"]

--- a/images/node-dev/10.16.3-v3/scripts/entrypoint.sh
+++ b/images/node-dev/10.16.3-v3/scripts/entrypoint.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Please Use Google Shell Style: https://google.github.io/styleguide/shell.xml
+
+# ---- Start unofficial bash strict mode boilerplate
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -o errexit  # always exit on error
+set -o errtrace # trap errors in functions as well
+set -o pipefail # don't ignore exit codes when piping output
+set -o posix    # more strict failures in subshells
+# set -x          # enable debugging
+
+IFS=$'\n\t'
+# ---- End unofficial bash strict mode boilerplate
+
+# change the app user's uid:gid to match the repo root directory's
+uid=$(stat -c "%u" .)
+if [[ "${uid}" == "0" ]]; then
+  # Never run as root even if directory is owned by root.
+  # Fall back to 1000 which we know is the app user
+  uid=1000
+fi
+run_user="node"
+usermod --uid "${uid}" --non-unique "${run_user}" |& grep -v "no changes" || true
+"$(dirname "${BASH_SOURCE[0]}")/fix-volumes.sh"
+command=(npm run start:dev)
+if [[ $# -gt 0 ]]; then
+  # shellcheck disable=SC2206
+  command=($@)
+fi
+echo "Installing dependencies..."
+if [[ -f /usr/local/src/app/yarn.lock ]]; then
+  echo "(Using Yarn because there is a yarn.lock file)"
+  su-exec node yarn install
+else
+  su-exec node npm install --no-audit
+fi
+echo "Starting the project in development mode..."
+unset IFS
+exec su-exec "${run_user}" "${command[@]}"

--- a/images/node-dev/12.10.0-v3/Dockerfile
+++ b/images/node-dev/12.10.0-v3/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:12.10.0-alpine
+
+# hadolint ignore=DL3018
+RUN apk --no-cache --update add bash curl less shadow su-exec tini vim python2 make
+SHELL ["/bin/bash", "-o", "pipefail", "-o", "errexit", "-u", "-c"]
+
+# Allow yarn/npm to create ./node_modules
+RUN chown node:node .
+
+# Install the latest version of NPM (as of when this
+# base image is built)
+RUN npm i -g npm@latest
+
+COPY ./scripts /usr/local/src/app-scripts
+
+WORKDIR /usr/local/src/app
+ENV PATH=$PATH:/usr/local/src/app/node_modules/.bin \
+    BUILD_ENV=development NODE_ENV=development
+
+# hadolint ignore=DL3002
+USER root
+ENTRYPOINT ["tini", "--", "/usr/local/src/app-scripts/entrypoint.sh"]

--- a/images/node-dev/12.10.0-v3/scripts/entrypoint.sh
+++ b/images/node-dev/12.10.0-v3/scripts/entrypoint.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Please Use Google Shell Style: https://google.github.io/styleguide/shell.xml
+
+# ---- Start unofficial bash strict mode boilerplate
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -o errexit  # always exit on error
+set -o errtrace # trap errors in functions as well
+set -o pipefail # don't ignore exit codes when piping output
+set -o posix    # more strict failures in subshells
+# set -x          # enable debugging
+
+IFS=$'\n\t'
+# ---- End unofficial bash strict mode boilerplate
+
+# change the app user's uid:gid to match the repo root directory's
+uid=$(stat -c "%u" .)
+if [[ "${uid}" == "0" ]]; then
+  # Never run as root even if directory is owned by root.
+  # Fall back to 1000 which we know is the app user
+  uid=1000
+fi
+run_user="node"
+usermod --uid "${uid}" --non-unique "${run_user}" |& grep -v "no changes" || true
+"$(dirname "${BASH_SOURCE[0]}")/fix-volumes.sh"
+command=(npm run start:dev)
+if [[ $# -gt 0 ]]; then
+  # shellcheck disable=SC2206
+  command=($@)
+fi
+echo "Installing dependencies..."
+if [[ -f /usr/local/src/app/yarn.lock ]]; then
+  echo "(Using Yarn because there is a yarn.lock file)"
+  su-exec node yarn install
+else
+  su-exec node npm install --no-audit
+fi
+echo "Starting the project in development mode..."
+unset IFS
+exec su-exec "${run_user}" "${command[@]}"

--- a/images/node-dev/CHANGELOG.md
+++ b/images/node-dev/CHANGELOG.md
@@ -3,3 +3,7 @@
 ## v2
 
 The `node-dev` images `10.16.3-v2` and `12.10.0-v2` are the same as `v1` except that the entry point script, if it sees a `yarn.lock` file, will install dependencies using Yarn instead.
+
+## v3
+
+Fix a bug in the `entrypoint.sh` script so it will not run as root.


### PR DESCRIPTION
The only actual change is falling back to uid 1000 if stat finds uid 0 on the mounted filesystem.


```
# change the app user's uid:gid to match the repo root directory's
uid=$(stat -c "%u" .)
if [[ "${uid}" == "0" ]]; then
  # Never run as root even if directory is owned by root.
  # Fall back to 1000 which we know is the app user
  uid=1000
fi
run_user="node"
usermod --uid "${uid}" --non-unique "${run_user}" |& grep -v "no changes" || true
```