### PR TITLE
fix: ensure fix-volumes uses node user on Mac

### DIFF
--- a/images/node-dev/10.16.3-v1/scripts/entrypoint.sh
+++ b/images/node-dev/10.16.3-v1/scripts/entrypoint.sh
@@ -16,7 +16,7 @@ IFS=$'\n\t'
 run_user="node"
 # change the node user's uid:gid to match the repo root directory's
 usermod --uid "$(stat -c "%u" .)" --non-unique "${run_user}" |& grep -v "no changes" || true
-"$(dirname "${BASH_SOURCE[0]}")/fix-volumes.sh"
+"$(dirname "${BASH_SOURCE[0]}")/fix-volumes.sh" "${run_user}"
 command=(npm run start:dev)
 if [[ $# -gt 0 ]]; then
   # shellcheck disable=SC2206

--- a/images/node-dev/10.16.3-v2/scripts/entrypoint.sh
+++ b/images/node-dev/10.16.3-v2/scripts/entrypoint.sh
@@ -16,7 +16,7 @@ IFS=$'\n\t'
 run_user="node"
 # change the node user's uid:gid to match the repo root directory's
 usermod --uid "$(stat -c "%u" .)" --non-unique "${run_user}" |& grep -v "no changes" || true
-"$(dirname "${BASH_SOURCE[0]}")/fix-volumes.sh"
+"$(dirname "${BASH_SOURCE[0]}")/fix-volumes.sh" "${run_user}"
 command=(npm run start:dev)
 if [[ $# -gt 0 ]]; then
   # shellcheck disable=SC2206

--- a/images/node-dev/10.16.3-v3/scripts/entrypoint.sh
+++ b/images/node-dev/10.16.3-v3/scripts/entrypoint.sh
@@ -22,7 +22,7 @@ if [[ "${uid}" == "0" ]]; then
 fi
 run_user="node"
 usermod --uid "${uid}" --non-unique "${run_user}" |& grep -v "no changes" || true
-"$(dirname "${BASH_SOURCE[0]}")/fix-volumes.sh"
+"$(dirname "${BASH_SOURCE[0]}")/fix-volumes.sh" "${run_user}"
 command=(npm run start:dev)
 if [[ $# -gt 0 ]]; then
   # shellcheck disable=SC2206

--- a/images/node-dev/10.16.3-v4/Dockerfile
+++ b/images/node-dev/10.16.3-v4/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:10.16.3-alpine
+
+# hadolint ignore=DL3018
+RUN apk --no-cache --update add bash curl less shadow su-exec tini vim python2 make
+SHELL ["/bin/bash", "-o", "pipefail", "-o", "errexit", "-u", "-c"]
+
+# Allow yarn/npm to create ./node_modules
+RUN chown node:node .
+
+# Install the latest version of NPM (as of when this
+# base image is built)
+RUN npm i -g npm@latest
+
+COPY ./scripts /usr/local/src/app-scripts
+
+WORKDIR /usr/local/src/app
+ENV PATH=$PATH:/usr/local/src/app/node_modules/.bin \
+    BUILD_ENV=development NODE_ENV=development
+
+# hadolint ignore=DL3002
+USER root
+ENTRYPOINT ["tini", "--", "/usr/local/src/app-scripts/entrypoint.sh"]

--- a/images/node-dev/10.16.3-v4/scripts/entrypoint.sh
+++ b/images/node-dev/10.16.3-v4/scripts/entrypoint.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Please Use Google Shell Style: https://google.github.io/styleguide/shell.xml
+
+# ---- Start unofficial bash strict mode boilerplate
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -o errexit  # always exit on error
+set -o errtrace # trap errors in functions as well
+set -o pipefail # don't ignore exit codes when piping output
+set -o posix    # more strict failures in subshells
+# set -x          # enable debugging
+
+IFS=$'\n\t'
+# ---- End unofficial bash strict mode boilerplate
+
+# change the app user's uid:gid to match the repo root directory's
+uid=$(stat -c "%u" .)
+if [[ "${uid}" == "0" ]]; then
+  # Never run as root even if directory is owned by root.
+  # Fall back to 1000 which we know is the app user
+  uid=1000
+fi
+run_user="node"
+usermod --uid "${uid}" --non-unique "${run_user}" |& grep -v "no changes" || true
+"$(dirname "${BASH_SOURCE[0]}")/fix-volumes.sh" "${run_user}"
+command=(npm run start:dev)
+if [[ $# -gt 0 ]]; then
+  # shellcheck disable=SC2206
+  command=($@)
+fi
+echo "Installing dependencies..."
+if [[ -f /usr/local/src/app/yarn.lock ]]; then
+  echo "(Using Yarn because there is a yarn.lock file)"
+  su-exec node yarn install
+else
+  su-exec node npm install --no-audit
+fi
+echo "Starting the project in development mode..."
+unset IFS
+exec su-exec "${run_user}" "${command[@]}"

--- a/images/node-dev/12.10.0-v1/scripts/entrypoint.sh
+++ b/images/node-dev/12.10.0-v1/scripts/entrypoint.sh
@@ -16,7 +16,7 @@ IFS=$'\n\t'
 run_user="node"
 # change the node user's uid:gid to match the repo root directory's
 usermod --uid "$(stat -c "%u" .)" --non-unique "${run_user}" |& grep -v "no changes" || true
-"$(dirname "${BASH_SOURCE[0]}")/fix-volumes.sh"
+"$(dirname "${BASH_SOURCE[0]}")/fix-volumes.sh" "${run_user}"
 command=(npm run start:dev)
 if [[ $# -gt 0 ]]; then
   # shellcheck disable=SC2206

--- a/images/node-dev/12.10.0-v2/scripts/entrypoint.sh
+++ b/images/node-dev/12.10.0-v2/scripts/entrypoint.sh
@@ -16,7 +16,7 @@ IFS=$'\n\t'
 run_user="node"
 # change the node user's uid:gid to match the repo root directory's
 usermod --uid "$(stat -c "%u" .)" --non-unique "${run_user}" |& grep -v "no changes" || true
-"$(dirname "${BASH_SOURCE[0]}")/fix-volumes.sh"
+"$(dirname "${BASH_SOURCE[0]}")/fix-volumes.sh" "${run_user}"
 command=(npm run start:dev)
 if [[ $# -gt 0 ]]; then
   # shellcheck disable=SC2206

--- a/images/node-dev/12.10.0-v3/scripts/entrypoint.sh
+++ b/images/node-dev/12.10.0-v3/scripts/entrypoint.sh
@@ -22,7 +22,7 @@ if [[ "${uid}" == "0" ]]; then
 fi
 run_user="node"
 usermod --uid "${uid}" --non-unique "${run_user}" |& grep -v "no changes" || true
-"$(dirname "${BASH_SOURCE[0]}")/fix-volumes.sh"
+"$(dirname "${BASH_SOURCE[0]}")/fix-volumes.sh" "${run_user}"
 command=(npm run start:dev)
 if [[ $# -gt 0 ]]; then
   # shellcheck disable=SC2206

--- a/images/node-dev/12.10.0-v4/Dockerfile
+++ b/images/node-dev/12.10.0-v4/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:12.10.0-alpine
+
+# hadolint ignore=DL3018
+RUN apk --no-cache --update add bash curl less shadow su-exec tini vim python2 make
+SHELL ["/bin/bash", "-o", "pipefail", "-o", "errexit", "-u", "-c"]
+
+# Allow yarn/npm to create ./node_modules
+RUN chown node:node .
+
+# Install the latest version of NPM (as of when this
+# base image is built)
+RUN npm i -g npm@latest
+
+COPY ./scripts /usr/local/src/app-scripts
+
+WORKDIR /usr/local/src/app
+ENV PATH=$PATH:/usr/local/src/app/node_modules/.bin \
+    BUILD_ENV=development NODE_ENV=development
+
+# hadolint ignore=DL3002
+USER root
+ENTRYPOINT ["tini", "--", "/usr/local/src/app-scripts/entrypoint.sh"]

--- a/images/node-dev/12.10.0-v4/scripts/entrypoint.sh
+++ b/images/node-dev/12.10.0-v4/scripts/entrypoint.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Please Use Google Shell Style: https://google.github.io/styleguide/shell.xml
+
+# ---- Start unofficial bash strict mode boilerplate
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -o errexit  # always exit on error
+set -o errtrace # trap errors in functions as well
+set -o pipefail # don't ignore exit codes when piping output
+set -o posix    # more strict failures in subshells
+# set -x          # enable debugging
+
+IFS=$'\n\t'
+# ---- End unofficial bash strict mode boilerplate
+
+# change the app user's uid:gid to match the repo root directory's
+uid=$(stat -c "%u" .)
+if [[ "${uid}" == "0" ]]; then
+  # Never run as root even if directory is owned by root.
+  # Fall back to 1000 which we know is the app user
+  uid=1000
+fi
+run_user="node"
+usermod --uid "${uid}" --non-unique "${run_user}" |& grep -v "no changes" || true
+"$(dirname "${BASH_SOURCE[0]}")/fix-volumes.sh" "${run_user}"
+command=(npm run start:dev)
+if [[ $# -gt 0 ]]; then
+  # shellcheck disable=SC2206
+  command=($@)
+fi
+echo "Installing dependencies..."
+if [[ -f /usr/local/src/app/yarn.lock ]]; then
+  echo "(Using Yarn because there is a yarn.lock file)"
+  su-exec node yarn install
+else
+  su-exec node npm install --no-audit
+fi
+echo "Starting the project in development mode..."
+unset IFS
+exec su-exec "${run_user}" "${command[@]}"

--- a/scripts/fix-volumes.sh
+++ b/scripts/fix-volumes.sh
@@ -13,26 +13,35 @@ set -o posix    # more strict failures in subshells
 IFS=$'\n\t'
 # ---- End unofficial bash strict mode boilerplate
 
+if [[ "$#" -ne 1 ]]; then
+  echo "Usage: $0 [desired_owner_user]" 1>&2
+  exit 1
+fi
+
 volumes=$(mount | grep -E '^/dev/' | grep -Ev ' on /etc/' || true)
 if [[ -z "${volumes}" ]]; then
-  exit
-fi
-owner=$(stat -c "%u:%g" .)
-if [[ "${owner}" =~ ^0: ]]; then
-  echo "$(basename "$0") aborting instead of chowning to root."
-  echo "Found owner ${owner} on ${PWD}."
+  echo "fix-volumes: No volumes found"
   exit
 fi
 
+desired_owner_user=$1
+owner="$(id -u ${desired_owner_user}):$(id -g ${desired_owner_user})"
+if [[ "${owner}" =~ ^0: ]]; then
+  echo "fix-volumes: $(basename "$0") aborting instead of chowning to root."
+  echo "fix-volumes: Found owner ${owner} on ${PWD}."
+  exit
+fi
+
+echo "fix-volumes: Fixing all volumes to be owned by user '${desired_owner_user}''"
 echo "${volumes}" | awk '{print $3}' | {
   while IFS= read -r dir; do
-    echo "${dir}"
     mkdir -p "${dir}"
     old_owner=$(stat -c "%u:%g" "${dir}")
     if [[ "$1" != "--force" && "${old_owner}" == "${owner}" ]]; then
+      echo "fix-volumes: Skipping volume ${dir}. Already owned by ${owner}"
       continue
     fi
-    printf "Fixing volume %s (before=%s after=%s)…" "${dir}" "${old_owner}" "${owner}"
+    printf "fix-volumes: Fixing volume %s (before=%s after=%s)…" "${dir}" "${old_owner}" "${owner}"
     chown -R "${owner}" "${dir}"
     chmod -R a+r,u+rw "${dir}"
     echo "✓"


### PR DESCRIPTION
## Problem
Using `stat -c "%u:%g" .` to determine the UID:GID does not work when the host machine is Mac OSX and the working directory (`.`) is itself a volume linked to the host machine. On Mac, the command will always show root (0:0) as the owner because all volumes are always owned by root. This is true even if the underlying image has this directory pre-created with different ownership. The volume ownership masks the ownership built into the image.

## Solution
Since the true purpose of `fix-volumes.sh` is to ensure that all volumes are owned by the same user who will run the command, my fix is to pass this user name into the script as an argument. Currently we could assume "node" user, but the script is more versatile if it accepts the user name as an argument because only the calling Dockerfile/entrypoint truly knows which user it will be running the command as.

### Versioning
Because all images are rebuilt and retagged on every merge to `trunk`, all versions of `node-dev` images are currently affected by this bug. So in addition to making a `v4`, which makes it easy to force-pull this change into any project, I also updated all existing images to pass the new argument to `fix-volumes.sh`

## Testing
1. Run `./dockerfiles.sh build images/node-dev/12.10.0-v4/Dockerfile` in this repo
2. In API repo, latest `release-3.0.0` branch, change the image to `reactioncommerce/node-dev:12.10.0-v4` in `docker-compose.dev.yml`
3. If you haven't already, `ln -s docker-compose.dev.yml docker-compose.override.yml` in the API project.
4. In API project, `dc down -v`, or at least delete the node_modules volume with something like `docker volume rm reaction_api_node_modules`
5. In API project, `dc up -d mongo`
6. In API project, `dc up api`.

In the logs you should see something like this:

```
api_1    | fix-volumes: Fixing all volumes to be owned by node
api_1    | fix-volumes: Fixing volume /usr/local/src/app/node_modules (before=0:0 after=1000:1000)…✓
```

And NPM packages should install without errors and the API should start.