### PR TITLE
Node 12.14.1 images

### DIFF
--- a/images/node-dev/12.14.1-v1/Dockerfile
+++ b/images/node-dev/12.14.1-v1/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:12.14.1-alpine
+
+# hadolint ignore=DL3018
+RUN apk --no-cache --update add bash curl less shadow su-exec tini vim python2 make
+SHELL ["/bin/bash", "-o", "pipefail", "-o", "errexit", "-u", "-c"]
+
+# Allow yarn/npm to create ./node_modules
+RUN mkdir -p /usr/local/src/app && chown node:node /usr/local/src/app
+
+# Install the latest version of NPM (as of when this
+# base image is built)
+RUN npm i -g npm@latest
+
+COPY ./scripts /usr/local/src/app-scripts
+
+WORKDIR /usr/local/src/app
+ENV PATH=$PATH:/usr/local/src/app/node_modules/.bin \
+    BUILD_ENV=development NODE_ENV=development
+
+# hadolint ignore=DL3002
+USER root
+ENTRYPOINT ["tini", "--", "/usr/local/src/app-scripts/entrypoint.sh"]

--- a/images/node-dev/12.14.1-v1/scripts/entrypoint.sh
+++ b/images/node-dev/12.14.1-v1/scripts/entrypoint.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# Please Use Google Shell Style: https://google.github.io/styleguide/shell.xml
+
+# ---- Start unofficial bash strict mode boilerplate
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -o errexit  # always exit on error
+set -o errtrace # trap errors in functions as well
+set -o pipefail # don't ignore exit codes when piping output
+set -o posix    # more strict failures in subshells
+# set -x          # enable debugging
+
+IFS=$'\n\t'
+# ---- End unofficial bash strict mode boilerplate
+
+# change the app user's uid:gid to match the repo root directory's
+uid=$(stat -c "%u" .)
+if [[ "${uid}" == "0" ]]; then
+  # Never run as root even if directory is owned by root.
+  # Fall back to 1000 which we know is the app user
+  uid=1000
+fi
+run_user="node"
+usermod --uid "${uid}" --non-unique "${run_user}" |& grep -v "no changes" || true
+
+"$(dirname "${BASH_SOURCE[0]}")/fix-volumes.sh" "${run_user}"
+
+command=(npm run start:dev)
+if [[ $# -gt 0 ]]; then
+  # shellcheck disable=SC2206
+  command=($@)
+  command_override=true
+fi
+
+if [[ -f /usr/local/src/app/package.json ]]; then
+  echo "Installing dependencies..."
+  if [[ -f /usr/local/src/app/yarn.lock ]]; then
+    echo "(Using Yarn because there is a yarn.lock file)"
+    su-exec node yarn install
+  else
+    su-exec node npm install --no-audit
+  fi
+fi
+
+if [[ "${command_override}" = true ]]; then
+  echo "Running '${command[@]}' as user ${run_user} in Docker container..."
+else
+  echo "Starting the project in development mode..."
+fi
+
+unset IFS
+exec su-exec "${run_user}" "${command[@]}"

--- a/images/node-dev/CHANGELOG.md
+++ b/images/node-dev/CHANGELOG.md
@@ -1,9 +1,16 @@
 # Change Log
 
-## v2
+## 12.14.1-v1
 
-The `node-dev` images `10.16.3-v2` and `12.10.0-v2` are the same as `v1` except that the entry point script, if it sees a `yarn.lock` file, will install dependencies using Yarn instead.
+Create a new image, `12.14.1-v1`, which:
 
-## v3
+- is updated to the 12.14.1 LTS version of Node
+- uses the same entry point script as `12.10.0-v3` but with a slight change to the last `echo` so that "Starting the project in development mode..." is printed only for `docker-compose up` and not for `docker-compose run`.
+
+## 10.16.3-v3 and 12.10.0-v3
 
 Fix a bug in the `entrypoint.sh` script so it will not run as root.
+
+## 10.16.3-v2 and 12.10.0-v2
+
+The `node-dev` images `10.16.3-v2` and `12.10.0-v2` are the same as `v1` except that the entry point script, if it sees a `yarn.lock` file, will install dependencies using Yarn instead.

--- a/images/node-dev/CHANGELOG.md
+++ b/images/node-dev/CHANGELOG.md
@@ -5,7 +5,11 @@
 Create a new image, `12.14.1-v1`, which:
 
 - is updated to the 12.14.1 LTS version of Node
-- uses the same entry point script as `12.10.0-v3` but with a slight change to the last `echo` so that "Starting the project in development mode..." is printed only for `docker-compose up` and not for `docker-compose run`.
+- uses the same entry point script as `12.10.0-v4` but with a slight change to the last `echo` so that "Starting the project in development mode..." is printed only for `docker-compose up` and not for `docker-compose run`.
+
+## 10.16.3-v4 and 12.10.0-v4
+
+Update the `fix-volumes.sh` script so it will fix volumes correctly on Mac while still working on Linux, too. Also better "fix-volumes" logging.
 
 ## 10.16.3-v3 and 12.10.0-v3
 

--- a/images/node-dev/README.md
+++ b/images/node-dev/README.md
@@ -15,7 +15,7 @@ There are multiple versions of the Docker image, which are pushed to DockerHub a
 Under the service in `docker-compose.yml`:
 
 ```
-image: reactioncommerce/node-dev:12.10.0-v1
+image: reactioncommerce/node-dev:12.14.1-v1
 volumes:
   - .:/usr/local/src/app:cached
   - reaction_api_node_modules:/usr/local/src/app/node_modules # do not link node_modules in, and persist it between dc up runs

--- a/images/node-prod/12.14.1-v1/Dockerfile
+++ b/images/node-prod/12.14.1-v1/Dockerfile
@@ -1,0 +1,46 @@
+FROM node:12.14.1-alpine
+
+# hadolint ignore=DL3018
+RUN apk --no-cache add bash curl less tini vim make python2
+SHELL ["/bin/bash", "-o", "pipefail", "-o", "errexit", "-u", "-c"]
+
+WORKDIR /usr/local/src/app
+ENV PATH=$PATH:/usr/local/src/app/node_modules/.bin
+
+# Allow yarn/npm to create ./node_modules
+RUN chown node:node .
+
+# Install the latest version of NPM (as of when this
+# base image is built)
+RUN npm i -g npm@latest
+
+# Copy specific things so that we can keep the image
+# as small as possible without relying on each repo
+# to include a .dockerignore file.
+#
+# Note that there is a reason these are on separate lines.
+# COPY command will fail unless at least one file exists
+# So we put LICENSE* on the same line as package-lock.json,
+# effectively making it optional to have a LICENSE file.
+# But the others are on their own line so that the build
+# will fail if they are not present in the project.
+ONBUILD COPY --chown=node:node package.json ./
+ONBUILD COPY --chown=node:node package-lock.json LICENSE* ./
+ONBUILD COPY --chown=node:node ./src ./src
+
+USER node
+
+# Install dependencies
+ONBUILD RUN npm ci --only=prod --ignore-scripts
+
+# If any Node flags are needed, they can be set in
+# the NODE_OPTIONS env variable.
+#
+# NOTE: We would prefer to use `node .` but relying on
+# Node to look up the `main` path is currently broken
+# when ECMAScript module support is enabled. When this
+# is fixed, change command to:
+#
+# CMD ["tini", "--", "node", "."]
+#
+CMD ["tini", "--", "npm", "start"]


### PR DESCRIPTION
Part of https://github.com/reactioncommerce/reaction/issues/5770

## Change
- Adds `reactioncommerce/node-dev:12.14.1-v1` image, which is identical to `reactioncommerce/node-dev:12.10.0-v4` except for the later Node version.
- Adds `reactioncommerce/node-prod:12.14.1-v1` image, which is identical to `reactioncommerce/node-prod:12.10.0-v1` except for the later Node version.

## Testing
Test this in conjunction with the Reaction API PR that pulls this in