### PR TITLE
feat: new meteor/1.10.2-v1 image

### DIFF
--- a/images/meteor/1.10.2-v1/Dockerfile
+++ b/images/meteor/1.10.2-v1/Dockerfile
@@ -1,0 +1,21 @@
+# Some Meteor commands fail if we use one of the slimmer Node images.
+# Meteor 1.10.2 ships with Node 12.16.1. Be sure to keep these two versions in sync
+# when making new versions of this image.
+FROM node:12.16.1
+
+SHELL ["/bin/bash", "-o", "pipefail", "-o", "errexit", "-u", "-c"]
+
+ENV METEOR_VERSION 1.10.2
+ENV PATH $PATH:/home/node/.meteor
+
+USER node
+
+# Install Meteor. Copy the install script to a temp file first, so that we can
+# replace the hard-coded `RELEASE` var in the script with the release we want installed.
+RUN wget -O /tmp/install_meteor.sh https://install.meteor.com \
+ && sed -i.bak "s/RELEASE=.*/RELEASE=\"$METEOR_VERSION\"/g" /tmp/install_meteor.sh \
+ && printf "\\n[-] Installing Meteor %s...\\n" "$METEOR_VERSION" \
+ && sh /tmp/install_meteor.sh \
+ && rm /tmp/install_meteor.sh
+
+LABEL maintainer="Reaction Commerce <engineering@reactioncommerce.com>"


### PR DESCRIPTION
## Changes
New `meteor/1.10.2-v1` image, same as previous Meteor image but with Node (12.16.1) and Meteor (1.10.2) version bumps.

## Why
This will allow Reaction Meteor apps to be updated to fix potential dependency vulnerabilities.

## Testing
You can build it locally with `./dockerfiles.sh build images/meteor/1.10.2-v1/Dockerfile` but it's probably easiest to test by merging this and then testing along with the upcoming PRs that will rely on this.